### PR TITLE
Update fleet health check

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,7 @@ services:
       - /mnt/data/docker/volumes/fleet/logs:/logs
       - /mnt/data/docker/volumes/fleet/vulndb:/vulndb
     healthcheck:
-      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8080/healthz"]
+      test: ["CMD", "wget", "-qO-", "http://127.0.0.1:8082/healthz"]
       interval: 10s
       timeout: 5s
       retries: 12


### PR DESCRIPTION
Since we're running on a non-standard port, the health check needs to use that port