### PR TITLE
docs: add Portainer deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
 # docker-fleetdm-stack
+
+## Usage
+
+Deploy the stack locally with Docker Compose:
+
+```bash
+docker compose up -d
+```
+
+## Deploying with Portainer
+
+Portainer can deploy this stack through the **Stacks** section:
+
+1. Create a new stack.
+2. Paste the contents of `docker-compose.yml` into the web editor.
+3. Set environment variables in the web interface or attach a `.env` file.
+4. After the variables are configured, click **Deploy the stack**.
+


### PR DESCRIPTION
## Summary
- add Usage section
- document how to deploy with Portainer

## Testing
- `npx --yes markdownlint-cli README.md` *(fails: 403 Forbidden)*
- `markdownlint README.md` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b6773db0248321bee16f4f06e2faeb